### PR TITLE
Fix scoped package names

### DIFF
--- a/src/gemfury-publish.js
+++ b/src/gemfury-publish.js
@@ -4,7 +4,12 @@ import {readFileSync} from "fs";
 export default function gemfuryPublish ({gemfuryUser, gemfuryApiKey}) {
     try {
         const pkg = JSON.parse(readFileSync("package.json"));
-        const file = `${pkg.name}-${pkg.version}.tgz`;
+        let name = pkg.name;
+        if (name.startsWith("@")) {
+            name = name.substring(1, name.length);
+            name = name.replace("/", "-");
+        }
+        const file = `${name}-${pkg.version}.tgz`;
         console.log("Packing npm module");
         execSync("npm pack");
         console.log("Uploading to gemfury");


### PR DESCRIPTION
Hey, thanks a lot for this useful npm package! We've been using it with scoped packages and the name generated by `npm pack` is different than the one in the `package.json`. Example:
package.json: @company/package
npm pack result: company-package

I've added functionality so when a package name starts with `@` it strips it out and replaces all occurrences of `/` with a `-` :)